### PR TITLE
Enable `kotlin.native.enableKlibsCrossCompilation` and verify that Apple target libraries can be published on Windows

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,3 +5,4 @@ org.gradle.jvmargs=-Xmx2G
 #kotlin.mpp.applyDefaultHierarchyTemplate=false
 # For Android
 android.useAndroidX=true
+kotlin.native.enableKlibsCrossCompilation = true


### PR DESCRIPTION
Resolve #58