### PR TITLE
Set up Cursor Cloud development environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,15 @@
 See [Copilot instructions](.github/copilot-instructions.md) for this repository.
 
 Organization-wide standards and open-source library map: [@huanshankeji/.github general agent instructions](https://github.com/huanshankeji/.github/blob/main/docs/general-agent-instructions.md).
+
+## Cursor Cloud specific instructions
+
+The build/test/run commands are documented in [Copilot instructions](.github/copilot-instructions.md); prefer those. Notes below are cloud-VM-specific caveats only.
+
+- **Toolchain**: The project targets **JDK 17** (per CI), not the VM's default JDK. Gradle is pinned to JDK 17 via `org.gradle.java.home` in `~/.gradle/gradle.properties`, and `JAVA_HOME` is set in `~/.bashrc`. Don't rely on `java -version` in a fresh non-login shell; Gradle uses the pinned home.
+- **Android SDK**: Installed at `~/android-sdk` (compileSdk 36) and referenced via `sdk.dir` in the git-ignored `local.properties`. It's required for the `demo` module (`com.android.application`) to even configure, so all Gradle tasks (including `check`) depend on it being present.
+- **Running the demo (headless-friendly targets)**:
+  - JS DOM: `./gradlew :compose-multiplatform-html-unified-demo:jsBrowserDevelopmentRun --continuous` → http://localhost:8080
+  - Wasm JS (Compose UI canvas): `./gradlew :compose-multiplatform-html-unified-demo:wasmJsBrowserDevelopmentRun --continuous` → http://localhost:8081 (auto-bumps to next port if 8080 is taken)
+- **Wasm JS canvas gotcha**: The Wasm target compiles and serves fine, but the Compose UI canvas often fails to render in the cloud VM's Chrome (blank screen + a swallowed `kotlin.RuntimeException` in `FlushCoroutineDispatcherChecker` during init). Root cause is that WebGL is **software-only** here (`chrome://gpu` shows "WebGL: Software only, hardware acceleration unavailable"); skiko needs a working GL context. Use the **JS DOM** target for visual validation in the cloud VM.
+- **JVM desktop demo** (`./gradlew :compose-multiplatform-html-unified-demo:run`) needs a GUI display and cannot run in the headless VM.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for this Kotlin Multiplatform project in the Cursor Cloud VM and documents cloud-specific caveats for future agents.

Only `AGENTS.md` is changed in the repo; toolchain installs (JDK 17, Android SDK) are captured in the VM snapshot, and a minimal Gradle warm-up is registered as the startup update script.

## What was set up

- **JDK 17** installed and pinned for Gradle via `~/.gradle/gradle.properties` (`org.gradle.java.home`) to match CI (the VM default was JDK 21).
- **Android SDK** (cmdline-tools, platform-tools, `platforms;android-36`, `build-tools;36.0.0`) at `~/android-sdk`, referenced from the git-ignored `local.properties`. Required because the `demo` module applies `com.android.application`.
- **Update script**: `./gradlew help --quiet` (lightweight, idempotent Gradle warm-up).

## Verification

| Check | Command | Result |
| --- | --- | --- |
| Library build | `./gradlew publishToMavenLocal` | ✅ BUILD SUCCESSFUL |
| Lint + tests | `./gradlew check` | ✅ BUILD SUCCESSFUL |
| JS DOM demo | `:...-demo:jsBrowserDevelopmentRun` → localhost:8080 | ✅ Ran + interacted end-to-end |
| Wasm JS demo | `:...-demo:wasmJsBrowserDevelopmentRun` → localhost:8081 | ⚠️ Compiles/serves; canvas blank (software-only WebGL) |

Hello-world interaction: navigated Home → Material 3, clicked the counter button (0→1→2→3), and confirmed the snackbar "Count incremented to 3".

<a href="https://cursor.com/agents/bc-98a00ded-4ce6-4d3b-8690-45a642cd23c8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fjs_dom_demo_material3_counter.mp4"><img src="https://cursor.com/artifacts/c/art-97459955-8203-4e21-bf21-1e1823bbea0f" alt="js_dom_demo_material3_counter.mp4" /></a>

![JS DOM home screen](https://cursor.com/artifacts/c/art-451f15d5-c737-47a9-ad50-b0a324c25ee9)
![Material 3 counter + snackbar](https://cursor.com/artifacts/c/art-d5769eae-3d98-4b15-831e-2e4ceefb5b14)

## Notes

- The Wasm JS Compose UI canvas fails to render in the headless VM because `chrome://gpu` reports WebGL as "Software only, hardware acceleration unavailable"; use the JS DOM target for visual validation. This and the toolchain details are documented under `## Cursor Cloud specific instructions` in `AGENTS.md`.
- The JVM desktop demo needs a GUI display and cannot run headless.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-98a00ded-4ce6-4d3b-8690-45a642cd23c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-98a00ded-4ce6-4d3b-8690-45a642cd23c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

